### PR TITLE
Disable auto reference of runtime assemblies

### DIFF
--- a/Runtime/Castle.Core.dll.meta
+++ b/Runtime/Castle.Core.dll.meta
@@ -8,7 +8,7 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:

--- a/Runtime/NSubstitute.dll.meta
+++ b/Runtime/NSubstitute.dll.meta
@@ -8,7 +8,7 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:

--- a/Runtime/System.Threading.Tasks.Extensions.dll.meta
+++ b/Runtime/System.Threading.Tasks.Extensions.dll.meta
@@ -8,7 +8,7 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:


### PR DESCRIPTION
When added by the UPM approach, NSubstitute assemblies will be referenced by all Unity assembly definitions. That's unnecessary because NSubstitute usually used by unit-test scripts.

Under the above situation, NSubstitute.dll is referenced by the exported main `.csproj` project. If sonar scanner is used to check C# code, the project will be treated as a test project, which will make the code scanning less useful.

To fix above concerns, This PR disables the `Auto Reference` options of runtime DLLs.

References

- [Unity - Manual: Plugin Inspector](https://docs.unity3d.com/2019.4/Documentation/Manual/PluginInspector.html)
- [Analysis of product projects vs. test projects · SonarSource/sonar-scanner-msbuild Wiki](https://github.com/SonarSource/sonar-scanner-msbuild/wiki/Analysis-of-product-projects-vs.-test-projects#implicit-project-categorisation)
* [sonar-scanner-msbuild/IsTestByReference.cs at master · SonarSource/sonar-scanner-msbuild](https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/src/SonarScanner.MSBuild.Tasks/IsTestByReference.cs#L35)